### PR TITLE
Windows compatibility: Conditionally toggles Process#spawn

### DIFF
--- a/lib/async/process/child.rb
+++ b/lib/async/process/child.rb
@@ -31,7 +31,13 @@ module Async
 				
 				@exit_status = nil
 				
-				@pid = ::Process.spawn(*args, **options, pgroup: true)
+				if Gem.win_platform?
+					options[:new_pgroup] = true
+				else
+					options[:pgroup] = true
+				end
+
+				@pid = ::Process.spawn(*args, **options)
 				
 				@thread = Thread.new do
 					_, @exit_status = ::Process.wait2(@pid)


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->
When launching processes on Windows, I received a failure, `ArgumentError: wrong exec option symbol: pgroup`  
Upon inspection of Process#spawn, I noticed that depending on the OS you either pass `pgroup:` or `new_pgroup:`.
This changes toggles based on `Gem.win_platform?` which should be stable as it's part of core.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.


## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

Thanks for your time.
